### PR TITLE
feat: rework words all route

### DIFF
--- a/doc/api.yaml
+++ b/doc/api.yaml
@@ -142,6 +142,18 @@ paths:
         description: group number
         schema:
           type: string
+      - name: amount
+        in: query
+        required: false
+        description: amount of words
+        schema:
+          type: string
+      - name: page
+        in: query
+        required: false
+        description: page number
+        schema:
+          type: string
     get:
       tags:
         - Words

--- a/src/resources/words/word.db.repository.js
+++ b/src/resources/words/word.db.repository.js
@@ -9,9 +9,11 @@ const getAll = async conditions => {
 };
 
 const getAllPages = async conditions => {
-  const { group } = conditions;
-
-  return Word.find({ group });
+  const { group, page, minPage } = conditions;
+  return Word.find({
+    group,
+    page: { $lte: page, $gte: minPage }
+  });
 };
 
 const get = async id => {


### PR DESCRIPTION
добавился пункт page, дефолтное значение - -1, для него поведение другое
Теперь в первую очередь в массив попадают слова с текущей страницы
затем с предыдущих страниц, если и там недостаточно - лезем в предыдущую группу, если есть, если нет - возвращаем что есть

@Iogsotot чтобы вытащить одним запросом 600 слов (одну группу) надо указать **amount** - нужное число (600)  параметр **page** игнорировать и, опционально, вписать параметр group (дефолтный 0)

🤢 Оно, вроде, работает, но выглядит ужасно, буду рад любым предложениям по улучшению 🤢